### PR TITLE
feat(mobile): add challenges tab experience

### DIFF
--- a/practice-app/mobile/api/challenges.ts
+++ b/practice-app/mobile/api/challenges.ts
@@ -1,0 +1,110 @@
+import tokenManager from "@/services/tokenManager";
+
+export interface Challenge {
+  id: number;
+  name: string;
+  description: string;
+  goal_quantity: string;
+  unit: string | null;
+  target_category: number | null;
+  target_subcategory: number | null;
+  start_date: string;
+  end_date: string;
+  entry_type: "individual" | "team" | "open";
+  template: number | null;
+  creator: number;
+  created_at: string;
+  participants_count: number;
+}
+
+export interface ChallengeListResponse {
+  count: number;
+  next: string | null;
+  previous: string | null;
+  results: Challenge[];
+}
+
+export type ChallengeStatus = "active" | "upcoming" | "past";
+
+export const getChallengeStatus = (
+  challenge: Pick<Challenge, "start_date" | "end_date">,
+  referenceDate: Date = new Date()
+): ChallengeStatus => {
+  const now = new Date(referenceDate);
+  now.setHours(0, 0, 0, 0);
+
+  const start = new Date(challenge.start_date);
+  start.setHours(0, 0, 0, 0);
+
+  const end = new Date(challenge.end_date);
+  end.setHours(23, 59, 59, 999);
+
+  if (now < start) return "upcoming";
+  if (now > end) return "past";
+  return "active";
+};
+
+export interface ChallengeParticipation {
+  id: number;
+  user: string;
+  challenge: string;
+  team: string | null;
+  progress: number;
+  status: string;
+  joined_at: string;
+  completed_at: string | null;
+  exited_at: string | null;
+}
+
+const CHALLENGES_ENDPOINT = "/v1/challenges/api/v1/challenges/";
+
+const parseJson = async <T>(response: Response, fallbackMessage: string): Promise<T> => {
+  let data: any = null;
+  try {
+    data = await response.json();
+  } catch {
+    data = null;
+  }
+
+  if (!response.ok) {
+    const message =
+      (data && (data.detail || data.message || data.error)) ||
+      fallbackMessage ||
+      "Request failed";
+    throw new Error(typeof message === "string" ? message : fallbackMessage);
+  }
+
+  return data as T;
+};
+
+export const getChallenges = async (): Promise<ChallengeListResponse> => {
+  const response = await tokenManager.authenticatedFetch(CHALLENGES_ENDPOINT);
+  return parseJson<ChallengeListResponse>(response, "Failed to load challenges.");
+};
+
+export const getChallengeById = async (id: number): Promise<Challenge> => {
+  const response = await tokenManager.authenticatedFetch(`${CHALLENGES_ENDPOINT}${id}/`);
+  return parseJson<Challenge>(response, "Failed to load challenge details.");
+};
+
+export const joinChallenge = async (id: number): Promise<ChallengeParticipation> => {
+  const response = await tokenManager.authenticatedFetch(
+    `/v1/challenges/api/v1/challenges/${id}/join/`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    }
+  );
+  return parseJson<ChallengeParticipation>(response, "Unable to join the challenge.");
+};
+
+export const leaveChallenge = async (id: number): Promise<void> => {
+  const response = await tokenManager.authenticatedFetch(
+    `/v1/challenges/api/v1/challenges/${id}/leave/`,
+    {
+      method: "DELETE",
+    }
+  );
+  await parseJson<null>(response, "Unable to leave the challenge.");
+};

--- a/practice-app/mobile/app/(tabs)/_layout.tsx
+++ b/practice-app/mobile/app/(tabs)/_layout.tsx
@@ -40,6 +40,13 @@ export default function TabLayout() {
             title: "Goals", tabBarIcon: ({ color }) => <Octicons name="goal" size={28} color={color} />, 
           }} 
         />
+        <Tabs.Screen
+          name="challenges"
+          options={{
+            title: "Challenges",
+            tabBarIcon: ({ color }) => <Ionicons name="trophy" size={26} color={color} />,
+          }}
+        />
         <Tabs.Screen 
           name="leaderboard" 
           options={{ 

--- a/practice-app/mobile/app/(tabs)/challenges/[id].tsx
+++ b/practice-app/mobile/app/(tabs)/challenges/[id].tsx
@@ -1,0 +1,471 @@
+import {
+  Challenge,
+  ChallengeStatus,
+  getChallengeById,
+  getChallengeStatus,
+  joinChallenge,
+  leaveChallenge,
+} from "@/api/challenges";
+import { useColors } from "@/constants/colors";
+import tokenManager from "@/services/tokenManager";
+import { Ionicons, MaterialCommunityIcons } from "@expo/vector-icons";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  ActivityIndicator,
+  Alert,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+
+interface WasteCategory {
+  id: number;
+  name: string;
+}
+
+interface WasteSubCategory {
+  id: number;
+  name: string;
+}
+
+const extractResults = <T,>(payload: any): T[] => {
+  if (!payload) return [];
+  if (Array.isArray(payload)) return payload as T[];
+  if (Array.isArray(payload.results)) return payload.results as T[];
+  return [];
+};
+
+const formatDate = (dateString: string) =>
+  new Date(dateString).toLocaleDateString("en-GB", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+  });
+
+export default function ChallengeDetailsScreen() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const challengeId = Number(id);
+
+  const colors = useColors();
+  const router = useRouter();
+
+  const [challenge, setChallenge] = useState<Challenge | null>(null);
+  const [status, setStatus] = useState<ChallengeStatus>("upcoming");
+  const [targetLabel, setTargetLabel] = useState<string>("General impact");
+  const [isLoading, setIsLoading] = useState(true);
+  const [isActionLoading, setIsActionLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [isParticipating, setIsParticipating] = useState(false);
+
+  const styles = useMemo(
+    () =>
+      StyleSheet.create({
+        container: { flex: 1, backgroundColor: colors.background },
+        contentContainer: { padding: 16, paddingBottom: 48 },
+        headerSpacer: { height: 12 },
+        backButton: {
+          backgroundColor: colors.background,
+          borderRadius: 22,
+          width: 44,
+          height: 44,
+          alignItems: "center",
+          justifyContent: "center",
+          borderWidth: 1,
+          borderColor: colors.borders,
+          shadowColor: "#000",
+          shadowOpacity: 0.08,
+          shadowRadius: 8,
+          shadowOffset: { width: 0, height: 2 },
+          elevation: 4,
+        },
+        card: {
+          marginTop: 24,
+          backgroundColor: colors.cb1,
+          borderRadius: 20,
+          padding: 20,
+          borderWidth: 1,
+          borderColor: colors.borders,
+          shadowColor: "#000",
+          shadowOffset: { width: 0, height: 2 },
+          shadowOpacity: 0.08,
+          shadowRadius: 10,
+          elevation: 4,
+          gap: 20,
+        },
+        titleRow: { flexDirection: "row", justifyContent: "space-between", alignItems: "center", gap: 16 },
+        titleText: { flex: 1, fontSize: 24, fontWeight: "700", color: colors.text },
+        statusBadge: {
+          paddingHorizontal: 14,
+          paddingVertical: 6,
+          borderRadius: 18,
+        },
+        statusText: { fontSize: 12, fontWeight: "700" },
+        description: { fontSize: 15, lineHeight: 22, color: colors.textSecondary },
+        infoSection: { gap: 12 },
+        infoRow: {
+          flexDirection: "row",
+          alignItems: "center",
+          gap: 12,
+          paddingVertical: 12,
+          borderRadius: 12,
+          backgroundColor: colors.cb2,
+          paddingHorizontal: 14,
+        },
+        infoText: { fontSize: 14, color: colors.textSecondary, flex: 1 },
+        infoHighlight: { fontSize: 15, fontWeight: "600", color: colors.text },
+        statsGrid: { flexDirection: "row", justifyContent: "space-between", gap: 12 },
+        statCard: {
+          flex: 1,
+          backgroundColor: colors.background,
+          borderRadius: 16,
+          padding: 16,
+          borderWidth: 1,
+          borderColor: colors.borders,
+          alignItems: "flex-start",
+          gap: 6,
+        },
+        statLabel: { fontSize: 12, color: colors.textSecondary, textTransform: "uppercase", letterSpacing: 0.6 },
+        statValue: { fontSize: 18, fontWeight: "700", color: colors.text },
+        actionSection: { gap: 12 },
+        primaryButton: {
+          backgroundColor: colors.primary,
+          borderRadius: 14,
+          paddingVertical: 14,
+          alignItems: "center",
+          flexDirection: "row",
+          justifyContent: "center",
+          gap: 8,
+        },
+        primaryButtonDisabled: {
+          backgroundColor: colors.inactive_button,
+        },
+        primaryButtonText: {
+          fontSize: 16,
+          fontWeight: "600",
+          color: colors.background,
+        },
+        primaryButtonTextDisabled: {
+          color: colors.inactive_text,
+        },
+        secondaryButton: {
+          borderRadius: 14,
+          paddingVertical: 14,
+          alignItems: "center",
+          flexDirection: "row",
+          justifyContent: "center",
+          gap: 8,
+          borderWidth: 1,
+          borderColor: colors.error,
+          backgroundColor: colors.background,
+        },
+        secondaryButtonText: {
+          fontSize: 16,
+          fontWeight: "600",
+          color: colors.error,
+        },
+        helperNotice: {
+          flexDirection: "row",
+          gap: 10,
+          borderRadius: 12,
+          padding: 12,
+          backgroundColor: colors.background,
+          borderWidth: 1,
+          borderColor: colors.borders,
+        },
+        helperText: { flex: 1, fontSize: 13, color: colors.textSecondary, lineHeight: 20 },
+        loaderContainer: { flex: 1, justifyContent: "center", alignItems: "center" },
+        errorContainer: {
+          flex: 1,
+          justifyContent: "center",
+          alignItems: "center",
+          padding: 24,
+          gap: 12,
+        },
+        errorTitle: { fontSize: 18, fontWeight: "600", color: colors.error },
+        errorMessage: { fontSize: 15, textAlign: "center", color: colors.textSecondary, lineHeight: 22 },
+        retryButton: {
+          marginTop: 8,
+          paddingHorizontal: 20,
+          paddingVertical: 12,
+          borderRadius: 12,
+          borderWidth: 1,
+          borderColor: colors.primary,
+        },
+        retryText: { color: colors.primary, fontWeight: "600" },
+      }),
+    [colors]
+  );
+
+  const statusPalette = useMemo(
+    () => ({
+      active: { backgroundColor: colors.primary, textColor: colors.background },
+      upcoming: { backgroundColor: colors.sun, textColor: colors.black },
+      past: { backgroundColor: colors.error, textColor: colors.background },
+    }),
+    [colors]
+  );
+
+  const statusInfo = statusPalette[status] ?? statusPalette.active;
+
+  const fetchChallengeDetails = useCallback(async () => {
+    if (Number.isNaN(challengeId)) {
+      setError("Challenge identifier is invalid.");
+      setIsLoading(false);
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const [challengeData, categoriesResponse, subCategoriesResponse] = await Promise.all([
+        getChallengeById(challengeId),
+        tokenManager.authenticatedFetch("/v1/waste/categories/"),
+        tokenManager.authenticatedFetch("/v1/waste/subcategories/"),
+      ]);
+
+      let categoryMap: Record<number, string> = {};
+      let subCategoryMap: Record<number, string> = {};
+
+      if (categoriesResponse.ok) {
+        const categoryPayload = await categoriesResponse.json();
+        categoryMap = extractResults<WasteCategory>(categoryPayload).reduce(
+          (acc, category) => ({ ...acc, [category.id]: category.name }),
+          {}
+        );
+      }
+
+      if (subCategoriesResponse.ok) {
+        const subCategoryPayload = await subCategoriesResponse.json();
+        subCategoryMap = extractResults<WasteSubCategory>(subCategoryPayload).reduce(
+          (acc, subCategory) => ({ ...acc, [subCategory.id]: subCategory.name }),
+          {}
+        );
+      }
+
+      setChallenge(challengeData);
+      setStatus(getChallengeStatus(challengeData));
+
+      if (challengeData.target_subcategory && subCategoryMap[challengeData.target_subcategory]) {
+        setTargetLabel(subCategoryMap[challengeData.target_subcategory]);
+      } else if (challengeData.target_category && categoryMap[challengeData.target_category]) {
+        setTargetLabel(categoryMap[challengeData.target_category]);
+      } else {
+        setTargetLabel("General impact");
+      }
+    } catch (fetchError) {
+      console.error("Failed to load challenge:", fetchError);
+      setError(fetchError instanceof Error ? fetchError.message : "Unable to load challenge.");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [challengeId]);
+
+  useEffect(() => {
+    fetchChallengeDetails();
+  }, [fetchChallengeDetails]);
+
+  const handleJoin = useCallback(async () => {
+    if (!challenge) return;
+    setIsActionLoading(true);
+    try {
+      await joinChallenge(challenge.id);
+      setIsParticipating(true);
+      setChallenge((prev) =>
+        prev
+          ? { ...prev, participants_count: (prev.participants_count ?? 0) + 1 }
+          : prev
+      );
+      Alert.alert("Joined challenge", "You're officially part of this challenge. Good luck!");
+    } catch (joinError) {
+      const message =
+        joinError instanceof Error ? joinError.message : "Could not join the challenge.";
+      Alert.alert("Join failed", message);
+    } finally {
+      setIsActionLoading(false);
+    }
+  }, [challenge]);
+
+  const handleLeave = useCallback(async () => {
+    if (!challenge) return;
+    Alert.alert(
+      "Leave challenge",
+      "Are you sure you want to leave this challenge?",
+      [
+        { text: "Cancel", style: "cancel" },
+        {
+          text: "Leave",
+          style: "destructive",
+          onPress: async () => {
+            setIsActionLoading(true);
+            try {
+              await leaveChallenge(challenge.id);
+              setIsParticipating(false);
+              setChallenge((prev) =>
+                prev
+                  ? {
+                      ...prev,
+                      participants_count: Math.max((prev.participants_count ?? 1) - 1, 0),
+                    }
+                  : prev
+              );
+              Alert.alert("Left challenge", "You have exited this challenge.");
+            } catch (leaveError) {
+              const message =
+                leaveError instanceof Error
+                  ? leaveError.message
+                  : "Could not leave the challenge.";
+              Alert.alert("Leave failed", message);
+            } finally {
+              setIsActionLoading(false);
+            }
+          },
+        },
+      ],
+      { cancelable: true }
+    );
+  }, [challenge]);
+
+  const goalValue = Number(challenge?.goal_quantity ?? 0);
+  const formattedGoal = Number.isFinite(goalValue)
+    ? goalValue.toLocaleString(undefined, { maximumFractionDigits: 2 })
+    : challenge?.goal_quantity ?? "";
+
+  const isJoinDisabled =
+    isParticipating || status !== "upcoming" || isActionLoading || !challenge;
+
+  return (
+    <SafeAreaView style={styles.container} edges={["top"]}>
+      <ScrollView contentContainerStyle={styles.contentContainer}>
+        <View style={styles.headerSpacer} />
+        <TouchableOpacity
+          style={styles.backButton}
+          onPress={() => router.back()}
+          accessibilityLabel="Go back"
+        >
+          <Ionicons name="arrow-back" size={22} color={colors.text} />
+        </TouchableOpacity>
+
+        {isLoading ? (
+          <View style={styles.loaderContainer}>
+            <ActivityIndicator size="large" color={colors.primary} />
+          </View>
+        ) : error ? (
+          <View style={styles.errorContainer}>
+            <Ionicons name="alert-circle" size={42} color={colors.error} />
+            <Text style={styles.errorTitle}>Unable to load challenge</Text>
+            <Text style={styles.errorMessage}>{error}</Text>
+            <TouchableOpacity style={styles.retryButton} onPress={fetchChallengeDetails}>
+              <Text style={styles.retryText}>Try again</Text>
+            </TouchableOpacity>
+          </View>
+        ) : challenge ? (
+          <View style={styles.card}>
+            <View style={styles.titleRow}>
+              <Text style={styles.titleText}>{challenge.name}</Text>
+              <View
+                style={[
+                  styles.statusBadge,
+                  { backgroundColor: statusInfo.backgroundColor },
+                ]}
+              >
+                <Text style={[styles.statusText, { color: statusInfo.textColor }]}>
+                  {status.charAt(0).toUpperCase() + status.slice(1)}
+                </Text>
+              </View>
+            </View>
+
+            <Text style={styles.description}>{challenge.description}</Text>
+
+            <View style={styles.infoSection}>
+              <View style={styles.infoRow}>
+                <Ionicons name="leaf-outline" size={20} color={colors.primary} />
+                <Text style={styles.infoText}>Focus area</Text>
+                <Text style={styles.infoHighlight}>{targetLabel}</Text>
+              </View>
+              <View style={styles.infoRow}>
+                <Ionicons name="calendar-outline" size={20} color={colors.primary} />
+                <Text style={styles.infoText}>Schedule</Text>
+                <Text style={styles.infoHighlight}>
+                  {formatDate(challenge.start_date)} - {formatDate(challenge.end_date)}
+                </Text>
+              </View>
+              <View style={styles.infoRow}>
+                <Ionicons name="people-outline" size={20} color={colors.primary} />
+                <Text style={styles.infoText}>Entry type</Text>
+                <Text style={styles.infoHighlight}>
+                  {challenge.entry_type.charAt(0).toUpperCase() + challenge.entry_type.slice(1)}
+                </Text>
+              </View>
+            </View>
+
+            <View style={styles.statsGrid}>
+              <View style={styles.statCard}>
+                <Text style={styles.statLabel}>Goal target</Text>
+                <Text style={styles.statValue}>
+                  {formattedGoal} {challenge.unit ?? ""}
+                </Text>
+              </View>
+              <View style={styles.statCard}>
+                <Text style={styles.statLabel}>Participants</Text>
+                <Text style={styles.statValue}>{challenge.participants_count ?? 0}</Text>
+              </View>
+            </View>
+
+            <View style={styles.actionSection}>
+              <TouchableOpacity
+                style={[
+                  styles.primaryButton,
+                  isJoinDisabled ? styles.primaryButtonDisabled : undefined,
+                ]}
+                disabled={isJoinDisabled}
+                onPress={handleJoin}
+                activeOpacity={0.85}
+              >
+                <MaterialCommunityIcons
+                  name="trophy-award"
+                  size={20}
+                  color={isJoinDisabled ? colors.inactive_text : colors.background}
+                />
+                <Text
+                  style={[
+                    styles.primaryButtonText,
+                    isJoinDisabled ? styles.primaryButtonTextDisabled : undefined,
+                  ]}
+                >
+                  {isParticipating ? "You're in" : "Join challenge"}
+                </Text>
+              </TouchableOpacity>
+
+              {isParticipating ? (
+                <TouchableOpacity
+                  style={styles.secondaryButton}
+                  onPress={handleLeave}
+                  disabled={isActionLoading}
+                >
+                  <Ionicons name="exit-outline" size={20} color={colors.error} />
+                  <Text style={styles.secondaryButtonText}>Leave challenge</Text>
+                </TouchableOpacity>
+              ) : null}
+
+              <View style={styles.helperNotice}>
+                <Ionicons name="bulb-outline" size={20} color={colors.primary} />
+                <Text style={styles.helperText}>
+                  {status === "upcoming"
+                    ? "Join now to secure your spot. We'll notify you when the challenge begins."
+                    : status === "active"
+                      ? "This challenge has already started. Joining opens again in future editions."
+                      : "Challenge has concluded. Keep an eye out for new opportunities soon."}
+                </Text>
+              </View>
+            </View>
+          </View>
+        ) : null}
+      </ScrollView>
+    </SafeAreaView>
+  );
+}

--- a/practice-app/mobile/app/(tabs)/challenges/_layout.tsx
+++ b/practice-app/mobile/app/(tabs)/challenges/_layout.tsx
@@ -1,0 +1,15 @@
+import { Stack } from "expo-router";
+
+export default function ChallengesLayout() {
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: false,
+        animation: "none",
+      }}
+    >
+      <Stack.Screen name="index" />
+      <Stack.Screen name="[id]" />
+    </Stack>
+  );
+}

--- a/practice-app/mobile/app/(tabs)/challenges/index.tsx
+++ b/practice-app/mobile/app/(tabs)/challenges/index.tsx
@@ -1,0 +1,352 @@
+import ChallengeCardView from "@/components/challenges/ChallengeCard";
+import {
+  Challenge,
+  ChallengeStatus,
+  getChallengeStatus,
+  getChallenges,
+} from "@/api/challenges";
+import { useColors } from "@/constants/colors";
+import tokenManager from "@/services/tokenManager";
+import { Ionicons } from "@expo/vector-icons";
+import { useFocusEffect, useRouter } from "expo-router";
+import React, { useCallback, useMemo, useState } from "react";
+import {
+  ActivityIndicator,
+  FlatList,
+  Image,
+  RefreshControl,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+
+type FilterValue = "all" | ChallengeStatus;
+
+interface WasteCategory {
+  id: number;
+  name: string;
+}
+
+interface WasteSubCategory {
+  id: number;
+  name: string;
+  category: number;
+}
+
+const filterOptions: { value: FilterValue; label: string }[] = [
+  { value: "all", label: "All challenges" },
+  { value: "active", label: "Active" },
+  { value: "upcoming", label: "Upcoming" },
+  { value: "past", label: "Past" },
+];
+
+const extractResults = <T,>(payload: any): T[] => {
+  if (!payload) return [];
+  if (Array.isArray(payload)) return payload as T[];
+  if (Array.isArray(payload.results)) return payload.results as T[];
+  return [];
+};
+
+export default function ChallengesScreen() {
+  const colors = useColors();
+  const router = useRouter();
+
+  const [challenges, setChallenges] = useState<Challenge[]>([]);
+  const [selectedFilter, setSelectedFilter] = useState<FilterValue>("all");
+  const [isLoading, setIsLoading] = useState(true);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [categoryLabels, setCategoryLabels] = useState<Record<number, string>>({});
+  const [subCategoryLabels, setSubCategoryLabels] = useState<Record<number, string>>({});
+
+  const styles = useMemo(
+    () =>
+      StyleSheet.create({
+        container: { flex: 1, backgroundColor: colors.background },
+        headerBar: {
+          height: "7%",
+          flexDirection: "row",
+          alignItems: "center",
+          justifyContent: "space-between",
+          paddingHorizontal: "4%",
+          paddingTop: 0,
+          backgroundColor: colors.background,
+          borderBottomWidth: 1,
+          borderBottomColor: colors.borders,
+        },
+        headerContent: { flexDirection: "row", alignItems: "center", gap: 12 },
+        headerLogo: { width: 48, height: 48 },
+        headerTitle: { fontSize: 24, fontWeight: "600", color: colors.primary },
+        headerSubtitle: { fontSize: 13, color: colors.textSecondary },
+        listContainer: { paddingHorizontal: 16, paddingBottom: 32 },
+        screenIntro: { paddingVertical: 20, gap: 6 },
+        filterBar: {
+          flexDirection: "row",
+          flexWrap: "wrap",
+          gap: 8,
+          marginVertical: 12,
+        },
+        filterChip: {
+          paddingVertical: 8,
+          paddingHorizontal: 14,
+          borderRadius: 20,
+          borderWidth: 1,
+          borderColor: colors.borders,
+          backgroundColor: colors.background,
+        },
+        filterChipActive: {
+          backgroundColor: colors.primary,
+          borderColor: colors.primary,
+        },
+        filterText: { fontSize: 13, fontWeight: "500", color: colors.text },
+        filterTextActive: { color: colors.background },
+        helperText: { fontSize: 14, color: colors.textSecondary, lineHeight: 20 },
+        errorBox: {
+          backgroundColor: "#FFF3F3",
+          borderRadius: 12,
+          padding: 16,
+          flexDirection: "row",
+          alignItems: "center",
+          gap: 10,
+          borderWidth: 1,
+          borderColor: colors.error,
+          marginBottom: 16,
+        },
+        errorText: { color: colors.error, flex: 1, fontSize: 14 },
+        loaderContainer: { paddingVertical: 40, alignItems: "center" },
+        emptyState: {
+          paddingVertical: 64,
+          alignItems: "center",
+          gap: 12,
+        },
+        emptyIcon: { fontSize: 44 },
+        emptyTitle: { fontSize: 18, fontWeight: "600", color: colors.text },
+        emptyText: {
+          fontSize: 14,
+          color: colors.textSecondary,
+          textAlign: "center",
+          lineHeight: 21,
+          paddingHorizontal: 16,
+        },
+      }),
+    [colors]
+  );
+
+  const getTargetLabel = useCallback(
+    (challenge: Challenge): string => {
+      if (challenge.target_subcategory && subCategoryLabels[challenge.target_subcategory]) {
+        return subCategoryLabels[challenge.target_subcategory];
+      }
+      if (challenge.target_category && categoryLabels[challenge.target_category]) {
+        return categoryLabels[challenge.target_category];
+      }
+      return "General impact";
+    },
+    [categoryLabels, subCategoryLabels]
+  );
+
+  const loadChallenges = useCallback(
+    async (opts?: { refresh?: boolean }) => {
+      if (opts?.refresh) {
+        setIsRefreshing(true);
+      } else {
+        setIsLoading(true);
+      }
+      setError(null);
+
+      try {
+        const [challengeData, categoriesResponse, subCategoriesResponse] = await Promise.all([
+          getChallenges(),
+          tokenManager.authenticatedFetch("/v1/waste/categories/"),
+          tokenManager.authenticatedFetch("/v1/waste/subcategories/"),
+        ]);
+
+        let categoryMap: Record<number, string> = {};
+        let subCategoryMap: Record<number, string> = {};
+
+        if (categoriesResponse.ok) {
+          const categoryPayload = await categoriesResponse.json();
+          const categories = extractResults<WasteCategory>(categoryPayload);
+          categoryMap = categories.reduce(
+            (acc, category) => ({ ...acc, [category.id]: category.name }),
+            {}
+          );
+        }
+
+        if (subCategoriesResponse.ok) {
+          const subCategoryPayload = await subCategoriesResponse.json();
+          const subCategories = extractResults<WasteSubCategory>(subCategoryPayload);
+          subCategoryMap = subCategories.reduce(
+            (acc, subCategory) => ({ ...acc, [subCategory.id]: subCategory.name }),
+            {}
+          );
+        }
+
+        setCategoryLabels(categoryMap);
+        setSubCategoryLabels(subCategoryMap);
+        setChallenges(challengeData.results ?? []);
+      } catch (fetchError) {
+        console.error("Failed to fetch challenges:", fetchError);
+        setError(
+          fetchError instanceof Error ? fetchError.message : "Failed to load challenges."
+        );
+      } finally {
+        setIsLoading(false);
+        setIsRefreshing(false);
+      }
+    },
+    []
+  );
+
+  useFocusEffect(
+    useCallback(() => {
+      loadChallenges();
+    }, [loadChallenges])
+  );
+
+  const orderedChallenges = useMemo(() => {
+    const decorated = challenges.map((challenge) => ({
+      challenge,
+      status: getChallengeStatus(challenge),
+    }));
+
+    const filtered =
+      selectedFilter === "all"
+        ? decorated
+        : decorated.filter((item) => item.status === selectedFilter);
+
+    const statusOrder: Record<ChallengeStatus, number> = {
+      active: 0,
+      upcoming: 1,
+      past: 2,
+    };
+
+    return [...filtered].sort((a, b) => {
+      const statusDifference = statusOrder[a.status] - statusOrder[b.status];
+      if (statusDifference !== 0) return statusDifference;
+
+      const aStart = new Date(a.challenge.start_date).getTime();
+      const bStart = new Date(b.challenge.start_date).getTime();
+      return aStart - bStart;
+    });
+  }, [challenges, selectedFilter]);
+
+  const onRefresh = useCallback(() => {
+    loadChallenges({ refresh: true });
+  }, [loadChallenges]);
+
+  const renderChallenge = useCallback(
+    ({ item }: { item: { challenge: Challenge; status: ChallengeStatus } }) => (
+      <ChallengeCardView
+        challenge={item.challenge}
+        status={item.status}
+        categoryName={getTargetLabel(item.challenge)}
+        onPress={() =>
+          router.push({
+            pathname: "/challenges/[id]",
+            params: { id: item.challenge.id.toString() },
+          })
+        }
+        actionLabel="View details"
+      />
+    ),
+    [router, getTargetLabel]
+  );
+
+  const listHeader = (
+    <View style={styles.screenIntro}>
+      <Text style={styles.headerTitle}>Take on eco challenges</Text>
+      <Text style={styles.helperText}>
+        Join themed challenges to earn points, compete with others, and build lasting habits.
+      </Text>
+
+      <View style={styles.filterBar}>
+        {filterOptions.map((option) => {
+          const isActive = selectedFilter === option.value;
+          return (
+            <TouchableOpacity
+              key={option.value}
+              style={[
+                styles.filterChip,
+                isActive ? styles.filterChipActive : undefined,
+              ]}
+              onPress={() => setSelectedFilter(option.value)}
+              activeOpacity={0.85}
+            >
+              <Text
+                style={[
+                  styles.filterText,
+                  isActive ? styles.filterTextActive : undefined,
+                ]}
+              >
+                {option.label}
+              </Text>
+            </TouchableOpacity>
+          );
+        })}
+      </View>
+
+      {error ? (
+        <View style={styles.errorBox}>
+          <Ionicons name="alert-circle" size={22} color={colors.error} />
+          <Text style={styles.errorText}>{error}</Text>
+          <TouchableOpacity onPress={() => loadChallenges()}>
+            <Ionicons name="refresh" size={20} color={colors.error} />
+          </TouchableOpacity>
+        </View>
+      ) : null}
+
+      {isLoading && !isRefreshing ? (
+        <View style={styles.loaderContainer}>
+          <ActivityIndicator size="large" color={colors.primary} />
+        </View>
+      ) : null}
+    </View>
+  );
+
+  return (
+    <SafeAreaView style={styles.container} edges={["top"]}>
+      <View style={styles.headerBar}>
+        <View style={styles.headerContent}>
+          <Image
+            source={require("@/assets/images/reversed-icon.png")}
+            style={styles.headerLogo}
+            resizeMode="contain"
+          />
+          <View>
+            <Text style={styles.headerTitle}>Challenges</Text>
+            <Text style={styles.headerSubtitle}>Explore, join, and make an impact</Text>
+          </View>
+        </View>
+      </View>
+
+      <FlatList
+        data={orderedChallenges}
+        keyExtractor={(item) => item.challenge.id.toString()}
+        renderItem={renderChallenge}
+        contentContainerStyle={styles.listContainer}
+        ListHeaderComponent={listHeader}
+        ListEmptyComponent={
+          !isLoading && !error ? (
+            <View style={styles.emptyState}>
+              <Text style={styles.emptyIcon}>🌿</Text>
+              <Text style={styles.emptyTitle}>No challenges yet</Text>
+              <Text style={styles.emptyText}>
+                Check back soon for new sustainability challenges curated by the community.
+              </Text>
+            </View>
+          ) : null
+        }
+        refreshControl={
+          <RefreshControl
+            refreshing={isRefreshing}
+            onRefresh={onRefresh}
+            tintColor={colors.primary}
+          />
+        }
+      />
+    </SafeAreaView>
+  );
+}

--- a/practice-app/mobile/components/challenges/ChallengeCard.tsx
+++ b/practice-app/mobile/components/challenges/ChallengeCard.tsx
@@ -1,0 +1,249 @@
+import { Challenge, ChallengeStatus } from "@/api/challenges";
+import { useColors } from "@/constants/colors";
+import { Ionicons, MaterialCommunityIcons } from "@expo/vector-icons";
+import React, { useMemo } from "react";
+import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
+
+interface ChallengeCardProps {
+  challenge: Challenge;
+  status: ChallengeStatus;
+  categoryName?: string;
+  onPress?: () => void;
+  onActionPress?: () => void;
+  actionLabel?: string;
+  isActionDisabled?: boolean;
+  isParticipating?: boolean;
+}
+
+const ChallengeCard: React.FC<ChallengeCardProps> = ({
+  challenge,
+  status,
+  categoryName,
+  onPress,
+  onActionPress,
+  actionLabel = "View details",
+  isActionDisabled = false,
+  isParticipating = false,
+}) => {
+  const colors = useColors();
+
+  const styles = useMemo(
+    () =>
+      StyleSheet.create({
+        card: {
+          backgroundColor: colors.cb1,
+          borderRadius: 16,
+          padding: 16,
+          marginBottom: 16,
+          borderWidth: 1,
+          borderColor: colors.borders,
+          shadowColor: "#000",
+          shadowOffset: { width: 0, height: 2 },
+          shadowOpacity: 0.08,
+          shadowRadius: 8,
+          elevation: 4,
+        },
+        header: {
+          flexDirection: "row",
+          justifyContent: "space-between",
+          alignItems: "center",
+          marginBottom: 12,
+        },
+        title: {
+          fontSize: 18,
+          fontWeight: "600",
+          color: colors.text,
+          flex: 1,
+          marginRight: 12,
+        },
+        statusBadge: {
+          paddingHorizontal: 12,
+          paddingVertical: 6,
+          borderRadius: 16,
+        },
+        statusText: {
+          fontSize: 12,
+          fontWeight: "600",
+        },
+        metaRow: {
+          flexDirection: "row",
+          flexWrap: "wrap",
+          gap: 12,
+          marginBottom: 16,
+        },
+        metaItem: {
+          flexDirection: "row",
+          alignItems: "center",
+          gap: 6,
+          backgroundColor: colors.cb2,
+          paddingHorizontal: 10,
+          paddingVertical: 6,
+          borderRadius: 12,
+        },
+        metaText: {
+          fontSize: 13,
+          color: colors.textSecondary,
+        },
+        description: {
+          fontSize: 14,
+          color: colors.textSecondary,
+          lineHeight: 20,
+          marginBottom: 16,
+        },
+        statsRow: {
+          flexDirection: "row",
+          justifyContent: "space-between",
+          marginBottom: 16,
+        },
+        statItem: {
+          flex: 1,
+          alignItems: "center",
+        },
+        statLabel: {
+          fontSize: 12,
+          color: colors.textSecondary,
+          marginBottom: 4,
+        },
+        statValue: {
+          fontSize: 16,
+          fontWeight: "600",
+          color: colors.text,
+        },
+        actionButton: {
+          marginTop: "auto",
+          backgroundColor: isActionDisabled ? colors.inactive_button : colors.primary,
+          paddingVertical: 12,
+          borderRadius: 12,
+          alignItems: "center",
+        },
+        actionText: {
+          fontSize: 15,
+          fontWeight: "600",
+          color: isActionDisabled ? colors.inactive_text : colors.background,
+        },
+        participationNotice: {
+          padding: 12,
+          borderRadius: 12,
+          backgroundColor: colors.background,
+          borderWidth: 1,
+          borderColor: colors.primary,
+          flexDirection: "row",
+          alignItems: "center",
+          gap: 8,
+          marginBottom: 16,
+        },
+        participationText: {
+          fontSize: 13,
+          fontWeight: "500",
+          color: colors.primary,
+          flex: 1,
+        },
+      }),
+    [colors, isActionDisabled]
+  );
+
+  const statusConfig = useMemo(
+    () => ({
+      active: { label: "Active", background: colors.primary, text: colors.background },
+      upcoming: { label: "Upcoming", background: colors.sun, text: colors.black },
+      past: { label: "Past", background: colors.error, text: colors.background },
+    }),
+    [colors]
+  );
+
+  const statusInfo = statusConfig[status];
+  const startDate = new Date(challenge.start_date).toLocaleDateString("en-GB", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+  });
+  const endDate = new Date(challenge.end_date).toLocaleDateString("en-GB", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+  });
+
+  const goalValue = Number(challenge.goal_quantity);
+  const formattedGoal = Number.isFinite(goalValue)
+    ? goalValue.toLocaleString(undefined, { maximumFractionDigits: 2 })
+    : challenge.goal_quantity;
+
+  return (
+    <View style={styles.card}>
+      <View style={styles.header}>
+        <Text style={styles.title}>{challenge.name}</Text>
+        <View style={[styles.statusBadge, { backgroundColor: statusInfo.background }]}>
+          <Text style={[styles.statusText, { color: statusInfo.text }]}>{statusInfo.label}</Text>
+        </View>
+      </View>
+
+      <View style={styles.metaRow}>
+        {categoryName ? (
+          <View style={styles.metaItem}>
+            <Ionicons name="leaf" size={16} color={colors.primary} />
+            <Text style={styles.metaText}>{categoryName}</Text>
+          </View>
+        ) : null}
+
+        <View style={styles.metaItem}>
+          <Ionicons name="people-outline" size={16} color={colors.primary} />
+          <Text style={styles.metaText}>
+            {challenge.entry_type.charAt(0).toUpperCase() + challenge.entry_type.slice(1)} entry
+          </Text>
+        </View>
+
+        <View style={styles.metaItem}>
+          <Ionicons name="time-outline" size={16} color={colors.primary} />
+          <Text style={styles.metaText}>
+            {startDate} - {endDate}
+          </Text>
+        </View>
+      </View>
+
+      <Text style={styles.description}>
+        {challenge.description.length > 160
+          ? `${challenge.description.substring(0, 157)}...`
+          : challenge.description}
+      </Text>
+
+      {isParticipating ? (
+        <View style={styles.participationNotice}>
+          <MaterialCommunityIcons name="check-decagram" size={20} color={colors.primary} />
+          <Text style={styles.participationText}>You are currently enrolled in this challenge.</Text>
+        </View>
+      ) : null}
+
+      <View style={styles.statsRow}>
+        <View style={styles.statItem}>
+          <Text style={styles.statLabel}>Goal</Text>
+          <Text style={styles.statValue}>
+            {formattedGoal} {challenge.unit ?? ""}
+          </Text>
+        </View>
+        <View style={styles.statItem}>
+          <Text style={styles.statLabel}>Participants</Text>
+          <Text style={styles.statValue}>{challenge.participants_count ?? 0}</Text>
+        </View>
+      </View>
+
+      <TouchableOpacity
+        disabled={isActionDisabled}
+        style={styles.actionButton}
+        onPress={onActionPress ?? onPress}
+        activeOpacity={0.85}
+      >
+        <Text style={styles.actionText}>{actionLabel}</Text>
+      </TouchableOpacity>
+
+      {onPress && onActionPress && onActionPress !== onPress ? (
+        <TouchableOpacity onPress={onPress} activeOpacity={0.7} style={{ marginTop: 12 }}>
+          <Text style={{ color: colors.primary, fontWeight: "600", textAlign: "center" }}>
+            View challenge details
+          </Text>
+        </TouchableOpacity>
+      ) : null}
+    </View>
+  );
+};
+
+export default ChallengeCard;

--- a/practice-app/mobile/constants/api.ts
+++ b/practice-app/mobile/constants/api.ts
@@ -1,4 +1,4 @@
-export const API_BASE_URL = 'http://192.168.111.11:8000/api';
+export const API_BASE_URL = 'http://192.168.1.3:8000/api';
 
 export const API_ENDPOINTS = {
   AUTH: {
@@ -48,5 +48,12 @@ export const API_ENDPOINTS = {
     CREATE_FROM_TEMPLATE: (templateId: number) => 
       `/api/v1/goals/goals/api-template/${templateId}/`,
     TEMPLATES: '/api/v1/goals/templates/',
+  },
+
+  CHALLENGES: {
+    LIST: '/v1/challenges/api/v1/challenges/',
+    DETAIL: (id: number) => `/v1/challenges/api/v1/challenges/${id}/`,
+    JOIN: (id: number) => `/v1/challenges/api/v1/challenges/${id}/join/`,
+    LEAVE: (id: number) => `/v1/challenges/api/v1/challenges/${id}/leave/`,
   },
 };

--- a/practice-app/mobile/package-lock.json
+++ b/practice-app/mobile/package-lock.json
@@ -90,7 +90,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.4.tgz",
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -1472,7 +1471,6 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
       "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -3540,7 +3538,6 @@
       "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-7.1.17.tgz",
       "integrity": "sha512-uEcYWi1NV+2Qe1oELfp9b5hTYekqWATv2cuwcOAg5EvsIsUPtzFrKIasgUXLBRGb9P7yR5ifoJ+ug4u6jdqSTQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@react-navigation/core": "^7.12.4",
         "escape-string-regexp": "^4.0.0",
@@ -3737,7 +3734,6 @@
       "integrity": "sha512-ukd93VGzaNPMAUPy0gRDSC57UuQbnH9Kussp7HBjM06YFi9uZTFhOvMSO2OKqXm1rSgzOE+pVx1k1PYHGwlc8Q==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -3809,7 +3805,6 @@
       "integrity": "sha512-EHrrEsyhOhxYt8MTg4zTF+DJMuNBzWwgvvOYNj/zm1vnaD/IC5zCXFehZv94Piqa2cRFfXrTFxIvO95L7Qc/cw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.44.1",
         "@typescript-eslint/types": "8.44.1",
@@ -4372,7 +4367,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5058,7 +5052,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.3",
         "caniuse-lite": "^1.0.30001741",
@@ -6198,7 +6191,6 @@
       "integrity": "sha512-hB4FIzXovouYzwzECDcUkJ4OcfOEkXTv2zRY6B9bkwjx/cprAq0uvm1nl7zvQ0/TsUk0zQiN4uPfJpB9m+rPMQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6396,7 +6388,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6635,7 +6626,6 @@
       "resolved": "https://registry.npmjs.org/expo/-/expo-54.0.10.tgz",
       "integrity": "sha512-49+IginEoKC+g125ZlRvUYNl9jKjjHcDiDnQvejNWlMQ0LtcFIWiFad/PLjmi7YqF/0rj9u3FNxqM6jNP16O0w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.0",
         "@expo/cli": "54.0.8",
@@ -6742,7 +6732,6 @@
       "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-18.0.9.tgz",
       "integrity": "sha512-sqoXHAOGDcr+M9NlXzj1tGoZyd3zxYDy215W6E0Z0n8fgBaqce9FAYQE2bu5X4G629AYig5go7U6sQz7Pjcm8A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@expo/config": "~12.0.9",
         "@expo/env": "~2.0.7"
@@ -6767,7 +6756,6 @@
       "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-14.0.8.tgz",
       "integrity": "sha512-bTUHaJWRZ7ywP8dg3f+wfOwv6RwMV3mWT2CDUIhsK70GjNGlCtiWOCoHsA5Od/esPaVxqc37cCBvQGQRFStRlA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fontfaceobserver": "^2.1.0"
       },
@@ -6818,7 +6806,6 @@
       "resolved": "https://registry.npmjs.org/expo-linking/-/expo-linking-8.0.8.tgz",
       "integrity": "sha512-MyeMcbFDKhXh4sDD1EHwd0uxFQNAc6VCrwBkNvvvufUsTYFq3glTA9Y8a+x78CPpjNqwNAamu74yIaIz7IEJyg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "expo-constants": "~18.0.8",
         "invariant": "^2.2.4"
@@ -10775,7 +10762,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10795,7 +10781,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -10832,7 +10817,6 @@
       "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.81.4.tgz",
       "integrity": "sha512-bt5bz3A/+Cv46KcjV0VQa+fo7MKxs17RCcpzjftINlen4ZDUl0I6Ut+brQ2FToa5oD0IB0xvQHfmsg2EDqsZdQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/create-cache-key-function": "^29.7.0",
         "@react-native/assets-registry": "0.81.4",
@@ -10899,7 +10883,6 @@
       "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.28.0.tgz",
       "integrity": "sha512-0msfJ1vRxXKVgTgvL+1ZOoYw3/0z1R+Ked0+udoJhyplC2jbVKIJ8Z1bzWdpQRCV3QcQ87Op0zJVE5DhKK2A0A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@egjs/hammerjs": "^2.0.17",
         "hoist-non-react-statics": "^3.3.0",
@@ -10938,7 +10921,6 @@
       "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-4.1.2.tgz",
       "integrity": "sha512-qzmQiFrvjm62pRBcj97QI9Xckc3EjgHQoY1F2yjktd0kpjhoyePeuTEXjYRCAVIy7IV/1cfeSup34+zFThFoHQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "react-native-is-edge-to-edge": "^1.2.1",
         "semver": "7.7.2"
@@ -10967,7 +10949,6 @@
       "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.6.1.tgz",
       "integrity": "sha512-/wJE58HLEAkATzhhX1xSr+fostLsK8Q97EfpfMDKo8jlOc1QKESSX/FQrhk7HhQH/2uSaox4Y86sNaI02kteiA==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
@@ -10978,7 +10959,6 @@
       "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.16.0.tgz",
       "integrity": "sha512-yIAyh7F/9uWkOzCi1/2FqvNvK6Wb9Y1+Kzn16SuGfN9YFJDTbwlzGRvePCNTOX0recpLQF3kc2FmvMUhyTCH1Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "react-freeze": "^1.0.0",
         "react-native-is-edge-to-edge": "^1.2.1",
@@ -10994,7 +10974,6 @@
       "resolved": "https://registry.npmjs.org/react-native-web/-/react-native-web-0.21.1.tgz",
       "integrity": "sha512-BeNsgwwe4AXUFPAoFU+DKjJ+CVQa3h54zYX77p7GVZrXiiNo3vl03WYDYVEy5R2J2HOPInXtQZB5gmj3vuzrKg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.6",
         "@react-native/normalize-colors": "^0.74.1",
@@ -11027,7 +11006,6 @@
       "resolved": "https://registry.npmjs.org/react-native-worklets/-/react-native-worklets-0.5.1.tgz",
       "integrity": "sha512-lJG6Uk9YuojjEX/tQrCbcbmpdLCSFxDK1rJlkDhgqkVi1KZzG7cdcBFQRqyNOOzR9Y0CXNuldmtWTGOyM0k0+w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/plugin-transform-arrow-functions": "^7.0.0-0",
         "@babel/plugin-transform-class-properties": "^7.0.0-0",
@@ -11115,7 +11093,6 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
       "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12538,7 +12515,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12745,7 +12721,6 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13515,7 +13490,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
Description

  - wire API client + tab stack for challenge list/detail with filtering and status badges
  - build shared ChallengeCard component for consistent styling
  - expose join/leave actions (UI optimistic)

  Testing

  - npm run lint (fails: legacy lint issues outside challenges)
  - npx expo run:android --device on Medium_Phone_API_36

  Note

  - joining currently fails until backend fixes ChallengeService.join (date vs datetime
    comparison and score → progress); backend team notified