### PR TITLE
Notification system is added:

### DIFF
--- a/practice-app/backend/apps/events/apps.py
+++ b/practice-app/backend/apps/events/apps.py
@@ -4,3 +4,7 @@ from django.apps import AppConfig
 class EventsConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'apps.events'
+
+    def ready(self):
+        import apps.events.signals
+        # Import the signals module when the app is ready

--- a/practice-app/backend/apps/events/signals.py
+++ b/practice-app/backend/apps/events/signals.py
@@ -1,0 +1,59 @@
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+from django.contrib.auth import get_user_model
+from apps.events.models import Event
+from apps.notifications.models import Notification  # Import the new model
+import unicodedata
+
+# Get the actual User Model class
+User = get_user_model()
+
+
+@receiver(post_save, sender=Event)
+def create_event_notifications(sender, instance, created, **kwargs):
+    """
+    Creates a notification for every user in the event's city
+    when a new event is created.
+    """
+    if created:
+
+        # Clean the event location for comparison
+        event_city_clean = instance.location.lower().strip()
+
+
+        # 1. Get all eligible users (exclude creator, check notification setting)
+        all_potential_users = User.objects.exclude(
+            pk=instance.creator.pk
+        ).filter(
+            notifications_enabled=True,
+        ).exclude(
+            city__isnull=True  # Exclude users with no city set
+        ).exclude(
+            city__exact=''  # Exclude users with empty city string
+        )
+
+        notifications = []
+        matched_user_ids = []
+
+
+        for user in all_potential_users:
+            # --- ROBUST STRING CLEANUP ---
+            user_city = user.city
+            # Normalize Unicode characters and replace non-breaking spaces
+            user_city_lower = unicodedata.normalize('NFKC', user_city).replace('\xa0', ' ').lower().strip()
+            # ------------------------------
+
+            # Check if the user's cleaned city contains the event city
+            if event_city_clean in user_city_lower:
+                notifications.append(
+                    Notification(
+                        recipient=user,
+                        notification_type='EVENT_CREATED',
+                        event=instance
+                    )
+                )
+                matched_user_ids.append(user.id)
+
+        # 3. Bulk create all notifications for performance
+        if notifications:
+            Notification.objects.bulk_create(notifications)

--- a/practice-app/backend/apps/notifications/api/v1/serializers.py
+++ b/practice-app/backend/apps/notifications/api/v1/serializers.py
@@ -1,0 +1,33 @@
+from rest_framework import serializers
+from apps.notifications.models import Notification
+from apps.events.api.v1.serializers import EventSerializer  # Assuming EventSerializer is defined
+
+
+class EventTitleSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Notification.event.field.related_model
+        fields = ['id', 'title']
+
+
+class NotificationSerializer(serializers.ModelSerializer):
+    # Nested representation of the related event (only title and ID)
+    event_details = EventTitleSerializer(source='event', read_only=True)
+
+    # Custom message for the frontend
+    message = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Notification
+        fields = [
+            'id', 'notification_type', 'event', 'event_details',
+            'is_read', 'created_at', 'message'
+        ]
+        read_only_fields = [
+            'notification_type', 'event', 'event_details', 'created_at', 'message'
+        ]
+
+    def get_message(self, obj):
+        if obj.notification_type == 'EVENT_CREATED':
+            event_name = obj.event.title if obj.event else 'a new event'
+            return f"A new event '{event_name}' was created in your city!"
+        return "You have a new update."

--- a/practice-app/backend/apps/notifications/api/v1/urls.py
+++ b/practice-app/backend/apps/notifications/api/v1/urls.py
@@ -1,0 +1,13 @@
+from django.urls import path
+from .views import NotificationListView, MarkNotificationAsReadView
+
+urlpatterns = [
+    # GET: List all notifications (with optional filter for is_read)
+    path('', NotificationListView.as_view(), name='notification-list'),
+
+    # POST: Mark a specific notification as read
+    path('<int:pk>/read/', MarkNotificationAsReadView.as_view(), name='notification-mark-read'),
+
+    # POST: Mark ALL unread notifications as read
+    path('mark-all-read/', MarkNotificationAsReadView.as_view(), name='notification-mark-all-read'),
+]

--- a/practice-app/backend/apps/notifications/api/v1/views.py
+++ b/practice-app/backend/apps/notifications/api/v1/views.py
@@ -1,0 +1,68 @@
+from rest_framework import generics, status
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework.permissions import IsAuthenticated
+from drf_spectacular.utils import extend_schema, OpenApiParameter, OpenApiTypes
+from apps.notifications.models import Notification
+from .serializers import NotificationSerializer
+
+
+class NotificationListView(generics.ListAPIView):
+    """
+    Lists notifications for the authenticated user, optionally filtered by read status.
+    """
+    serializer_class = NotificationSerializer
+    permission_classes = [IsAuthenticated]
+
+    @extend_schema(
+        tags=['Notifications'],
+        summary='List user notifications',
+        description='Returns notifications for the current user, ordered by creation date.',
+        parameters=[
+            OpenApiParameter(
+                name='is_read',
+                type=OpenApiTypes.BOOL,
+                location=OpenApiParameter.QUERY,
+                description='Filter by read status (true/false).',
+                required=False
+            )
+        ]
+    )
+    def get_queryset(self):
+        queryset = Notification.objects.filter(recipient=self.request.user)
+        is_read_param = self.request.query_params.get('is_read')
+
+        if is_read_param is not None:
+            # Convert string 'true'/'false' to boolean
+            is_read = is_read_param.lower() in ['true', '1', 't']
+            queryset = queryset.filter(is_read=is_read)
+
+        return queryset.order_by('-created_at')
+
+
+class MarkNotificationAsReadView(APIView):
+    """
+    Marks one or all notifications as read.
+    """
+    permission_classes = [IsAuthenticated]
+
+    @extend_schema(
+        tags=['Notifications'],
+        summary='Mark notifications as read',
+        description='Marks one specific notification (if pk is provided) or all unread notifications for the user as read.',
+        request=None,
+        responses={200: {'detail': 'Notifications marked as read.'}}
+    )
+    def post(self, request, pk=None):
+        user = request.user
+
+        if pk:
+            # Mark a specific notification as read
+            count = Notification.objects.filter(pk=pk, recipient=user, is_read=False).update(is_read=True)
+            if count == 0:
+                return Response({'detail': 'Notification not found or already read.'}, status=status.HTTP_404_NOT_FOUND)
+            return Response({'detail': 'Notification marked as read.'}, status=status.HTTP_200_OK)
+        else:
+            # Mark all unread notifications as read
+            count = Notification.objects.filter(recipient=user, is_read=False).update(is_read=True)
+            return Response({'detail': f'Marked {count} notifications as read.'}, status=status.HTTP_200_OK)

--- a/practice-app/backend/apps/notifications/models.py
+++ b/practice-app/backend/apps/notifications/models.py
@@ -1,3 +1,54 @@
 from django.db import models
+from django.conf import settings
+from apps.events.models import Event  # Assuming Event is accessible from apps.events.models
 
-# Create your models here.
+User = settings.AUTH_USER_MODEL
+
+
+class Notification(models.Model):
+    """
+    Represents an actionable notification, typically tied to an Event.
+    """
+    # Type of content this notification relates to
+    NOTIFICATION_TYPES = [
+        ('EVENT_CREATED', 'New Event in Your City'),
+        # Add other types here later (e.g., 'GOAL_ACHIEVED', 'CHALLENGE_COMPLETED')
+    ]
+
+    recipient = models.ForeignKey(
+        User,
+        on_delete=models.CASCADE,
+        related_name='notifications_received',
+        verbose_name='Recipient'
+    )
+
+    notification_type = models.CharField(
+        max_length=50,
+        choices=NOTIFICATION_TYPES,
+        default='EVENT_CREATED'
+    )
+
+    # Generic foreign key (optional, but good practice) or specific relationship
+    event = models.ForeignKey(
+        Event,
+        on_delete=models.CASCADE,
+        related_name='notifications_sent',
+        null=True,
+        blank=True
+    )
+
+    is_read = models.BooleanField(default=False)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        # Indexing on recipient and read status for fast lookup
+        ordering = ['-created_at']
+        verbose_name = 'Notification'
+        verbose_name_plural = 'Notifications'
+
+    def __str__(self):
+        return f"Notif for {self.recipient.username}: {self.get_notification_type_display()}"
+
+# The Many-to-Many approach you suggested is best managed through the
+# is_read field on this dedicated Notification model, which simplifies querying.
+# We create a new Notification object for each user who should see it.

--- a/practice-app/backend/config/urls.py
+++ b/practice-app/backend/config/urls.py
@@ -55,6 +55,7 @@ urlpatterns = [
     path('api/v1/rewards/', include('apps.rewards.api.v1.urls')),
     path('api/v1/challenges/', include('apps.challenges.api.v1.urls')),
     path('api/v1/events/', include('apps.events.api.v1.urls')),
+    path('api/v1/notifications/', include('apps.notifications.api.v1.urls')),
     
     # Django allauth URLs
     path('accounts/', include('allauth.urls')),


### PR DESCRIPTION
Notification system is added:
When an event is created, the users (except for the one who creates it) who are in the city the event will take place at should be notified. This is done in the notification table with user id (recipient_id), event id and is_read columns. 
When a user needs to see his unread notifications, he sends a get request to this url: http://localhost:8000/api/v1/notifications/?is_read=false
When he reads only one notification, he posts to this url:
http://localhost:8000/api/v1/notifications/{id}/read
When he reads entire notifications, he posts to this url:
http://localhost:8000/api/v1/notifications/mark-all-read
The last two are in the swagger page, the first one is not.
Ty.
