### PR TITLE
add blacklist feature for events

### DIFF
--- a/practice-app/backend/config/settings.py
+++ b/practice-app/backend/config/settings.py
@@ -121,6 +121,17 @@ DATABASES = {
     }
 }
 
+# Content Moderation Settings
+# List of blacklisted words for content moderation
+BLACKLISTED_WORDS = [
+    "spam",
+    "scam",
+    "abuse",
+    "violence",
+    "hate",
+    "drugs",
+]
+
 
 # Password validation
 # https://docs.djangoproject.com/en/4.2/ref/settings/#auth-password-validators


### PR DESCRIPTION
I've added blacklist feature for event's title and description. You may see the blacklisted words from settings.py. This is only for test purposes so we can improve our blacklist and add this to other fields in our application, as well. 