### PR TITLE
updated serializers.py for new event fields: Added the new fields to fields list: Included 'duration', 'equipment_needed', and 'exact_location'.

### DIFF
--- a/practice-app/backend/apps/events/api/v1/serializers.py
+++ b/practice-app/backend/apps/events/api/v1/serializers.py
@@ -13,6 +13,8 @@ class EventSerializer(serializers.ModelSerializer):
         model = Event
         fields = [
             'id', 'title', 'description', 'location', 'date', 'image',
+            # 👇 NEW FIELDS ADDED HERE 👇
+            'duration', 'equipment_needed', 'exact_location',
             'creator', 'creator_username',
             'participants_count', 'likes_count',
             'i_am_participating', 'i_liked',
@@ -22,26 +24,34 @@ class EventSerializer(serializers.ModelSerializer):
 
     ## BLACKLISTED WORDS VALIDATION ##
     def validate(self, data):
+        # Get all text fields
         title = data.get("title", "")
         description = data.get("description", "")
+        equipment = data.get("equipment_needed", "") # Check this too
+        location_detail = data.get("exact_location", "") # Check this too
 
         banned = getattr(settings, "BLACKLISTED_WORDS", [])
 
-        lower_title = title.lower()
-        lower_desc = description.lower()
+        # Combine text for checking or check individually
+        # Checking individually allows specific error messages
+        fields_to_check = {
+            "title": title,
+            "description": description,
+            "equipment_needed": equipment,
+            "exact_location": location_detail
+        }
 
-        for word in banned:
-            w = word.lower()
-
-            if w in lower_title:
-                raise serializers.ValidationError({
-                    "title": f"Title contains banned word: '{word}'"
-                })
-
-            if w in lower_desc:
-                raise serializers.ValidationError({
-                    "description": f"Description contains banned word: '{word}'"
-                })
+        for field_name, value in fields_to_check.items():
+            if not value: continue # Skip empty fields
+            
+            lower_value = str(value).lower()
+            
+            for word in banned:
+                w = word.lower()
+                if w in lower_value:
+                    raise serializers.ValidationError({
+                        field_name: f"{field_name.replace('_', ' ').capitalize()} contains banned word: '{word}'"
+                    })
 
         return data
 


### PR DESCRIPTION
@atakemin can you check practice-app/backend/apps/events/api/v1/serializers.py. I think it needs update too. You successfully added the new fields (duration, equipment_needed, exact_location) to models in the previous step, but I think you haven't added them to this serializer.

If we use the code as is, the frontend will send the data (District, Duration, Equipment), but the backend will ignore it because those fields aren't listed in Meta.fields.