### PR TITLE
add new timeframes & subcategory info

### DIFF
--- a/practice-app/backend/apps/waste/api/v1/serializers.py
+++ b/practice-app/backend/apps/waste/api/v1/serializers.py
@@ -103,9 +103,19 @@ class UserRankingSerializer(serializers.ModelSerializer):
         return obj.username
 
 
-
 class WasteStatsItemSerializer(serializers.Serializer):
     start_date = serializers.DateField()
     end_date = serializers.DateField()
     total_score = serializers.FloatField()
     total_log = serializers.IntegerField()
+
+    def to_representation(self, instance):
+        # Start with the default fields
+        rep = super().to_representation(instance)
+
+        # Add any dynamic fields (subcategory_* keys)
+        for key, value in instance.items():
+            if key not in rep:
+                rep[key] = value
+
+        return rep

--- a/practice-app/backend/requirements.txt
+++ b/practice-app/backend/requirements.txt
@@ -20,3 +20,4 @@ factory-boy>=3.3.0
 pytest-factoryboy>=1.1.0
 pytest-cov>=4.1.0
 responses>=0.23.0
+dateutil


### PR DESCRIPTION
I've added new timeframes and updated the response. 

* New timeframes: monthly (last 12 months) & yearly (last 3 years). 

Example usage: `http://127.0.0.1:8000/api/v1/waste/user/stats/?period=monthly`

**Important Note: Do not forget to run `pip install -r requirements.txt` because there is a new library addition.**

* Updated response: Now the response includes the total scores and count of logs in that timespan, for each subcategory with at least 1 log. 

Example response:

```
{
    "period": "daily",
    "data": [
        {
            "start_date": "2025-12-07",
            "end_date": "2025-12-07",
            "total_score": 0.0,
            "total_log": 0
        },...
        {
            "start_date": "2025-12-12",
            "end_date": "2025-12-12",
            "total_score": 0.0,
            "total_log": 0
        },
        {
            "start_date": "2025-12-13",
            "end_date": "2025-12-13",
            "total_score": 17.6,
            "total_log": 3,
            "subcategory_1_score": 5.0,
            "subcategory_1_log": 1,
            "subcategory_3_score": 12.6,
            "subcategory_3_log": 2
        }
    ]
}


Please see that we have additional key-value pairs such as subcategory_x_score and subcategory_x_log. Other subcategories are missing because there is no related log for them. 
```