### PR TITLE
(hotfix) Update dateutil to python-dateutil in requirements

### DIFF
--- a/practice-app/backend/requirements.txt
+++ b/practice-app/backend/requirements.txt
@@ -20,4 +20,4 @@ factory-boy>=3.3.0
 pytest-factoryboy>=1.1.0
 pytest-cov>=4.1.0
 responses>=0.23.0
-dateutil
+python-dateutil


### PR DESCRIPTION
Previous requirements.txt file were mistakenly using dateutil instead of python-dateutil, causing compatability issues