### PR TITLE
fix: Improve logic and UI for Personal Stats, Leaderboard, and Dashboard

### DIFF
--- a/practice-app/frontend-web/src/components/dashboard/Dashboard.js
+++ b/practice-app/frontend-web/src/components/dashboard/Dashboard.js
@@ -77,13 +77,14 @@ const Dashboard = () => {
     const getNextMilestoneInfo = (currentScore) => {
         if (!currentScore) currentScore = 0;
         
+        // Removed the 'message' property; only 'label' and 'score' are sufficient
         const milestones = [
-            { score: 500, label: 'rising_star', message: 'Log waste to reach 500 points and earn Rising Star badge!' },
-            { score: 1000, label: 'tree_hugger', message: 'Log waste to reach 1000 points and plant your first tree!' },
-            { score: 1500, label: 'green_achiever', message: 'Log waste to reach 1500 points and earn Green Achiever badge!' },
-            { score: 2000, label: 'eco_champion', message: 'Log waste to reach 2000 points and become an Eco Champion!' },
-            { score: 3000, label: 'eco_master', message: 'Log waste to reach 3000 points and become an Eco Master!' },
-            { score: 5000, label: 'zero_waste_legend', message: 'Log waste to reach 5000 points and become a Zero Waste Legend!' }
+            { score: 500, label: 'rising_star' },
+            { score: 1000, label: 'tree_hugger' },
+            { score: 1500, label: 'green_achiever' },
+            { score: 2000, label: 'eco_champion' },
+            { score: 3000, label: 'eco_master' },
+            { score: 5000, label: 'zero_waste_legend' }
         ];
 
         const nextMilestone = milestones.find(m => m.score > currentScore);
@@ -91,10 +92,9 @@ const Dashboard = () => {
         if (!nextMilestone) {
             return {
                 nextScore: 5000,
-                itemsNeeded: 0,
                 pointsNeeded: 0,
-                milestone: 'Complete',
-                message: 'You\'ve reached all major milestones! Keep going to maintain your achievements!'
+                itemsNeeded: 0,
+                milestoneLabel: 'complete' // Returning as a label
             };
         }
 
@@ -105,8 +105,7 @@ const Dashboard = () => {
             nextScore: nextMilestone.score,
             pointsNeeded,
             itemsNeeded,
-            milestone: nextMilestone.label,
-            message: nextMilestone.message
+            milestoneLabel: nextMilestone.label // Returning as a label
         };
     };
 
@@ -124,7 +123,7 @@ const Dashboard = () => {
                         <h3>{firstName}</h3>
                         <p className="user-email-display">{email}</p>
                         <p className="user-role-display">
-                           {t('dashboard.profile_card.role_prefix')}: {role || t('dashboard.profile_card.member')}
+                            {t('dashboard.profile_card.role_prefix')}: {role ? t(`dashboard.roles.${role.toLowerCase()}`) : t('dashboard.profile_card.member')}
                         </p>
                         <Link to="/profile" className="profile-action-button view-profile-btn">
                             <Icon name="edit" /> {t('dashboard.profile_card.view_profile_button')}
@@ -180,12 +179,16 @@ const Dashboard = () => {
                                             const milestone = getNextMilestoneInfo(score);
                                             return (
                                                 <>
-                                                    <p className="next-step-message">{milestone.message}</p>
+                                                    {/* 1. Milestone Message Translation */}
+                                                    <p className="next-step-message">
+                                                        {t(`dashboard.milestones.${milestone.milestoneLabel}`)}
+                                                    </p>
+                                
                                                     {milestone.pointsNeeded > 0 && (
                                                         <div className="milestone-progress">
                                                             <div className="progress-info">
                                                                 <span className="progress-label">
-                                                                    {t('dashboard.next_step_widget.current_score', { defaultValue: 'Current Score' })}: <strong>{score}</strong>
+                                                                    {t('dashboard.next_step_widget.current_score')}: <strong>{score}</strong>
                                                                 </span>
                                                                 <span className="progress-points">
                                                                     / {milestone.nextScore} {t('dashboard.score_widget.unit')}
@@ -200,12 +203,20 @@ const Dashboard = () => {
                                                                         }}
                                                                     ></div>
                                                                 </div>
-                                                                <span className="progress-text">{Math.round((score / milestone.nextScore) * 100)}% - Need {milestone.pointsNeeded} more {t('dashboard.score_widget.unit')}</span>
+                                                                {/* 2. Progress Text Translation (Interpolation) */}
+                                                                <span className="progress-text">
+                                                                    {t('dashboard.next_step_widget.progress_text', {
+                                                                        percent: Math.round((score / milestone.nextScore) * 100),
+                                                                        needed: milestone.pointsNeeded,
+                                                                        unit: t('dashboard.score_widget.unit')
+                                                                    })}
+                                                                </span>
                                                             </div>
                                                         </div>
                                                     )}
+                                                    {/* ... Button section remains the same ... */}
                                                     <Link to="/waste" className="next-step-button">
-                                                        <Icon name="waste" /> {t('dashboard.next_step_widget.log_now', { defaultValue: 'Log Waste Now' })}
+                                                        <Icon name="waste" /> {t('dashboard.next_step_widget.log_now')}
                                                     </Link>
                                                 </>
                                             );

--- a/practice-app/frontend-web/src/components/leaderboard/LeaderboardPage.js
+++ b/practice-app/frontend-web/src/components/leaderboard/LeaderboardPage.js
@@ -21,9 +21,9 @@ const LeaderboardPage = () => {
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState('');
     
-    // YENİ: Zaman dilimi state'i (Varsayılan: 'all')
-    // Seçenekler: 'all', 'yearly', 'monthly', 'weekly', 'daily'
-    const [timeframe, setTimeframe] = useState('all');
+    // DISABLED.
+    // Defaulting to showing all-time data only.
+    // const [timeframe, setTimeframe] = useState('all');
 
     const navigate = useNavigate();
     const currentUserId = localStorage.getItem('user_id'); 
@@ -41,8 +41,8 @@ const LeaderboardPage = () => {
         const fetchLeaderboard = async () => {
             setLoading(true);
             try {
-                // YENİ: timeframe parametresini gönderiyoruz
-                const rawData = await getLeaderboard(timeframe); 
+                // CHANGE: Removed timeframe parameter, backend returns default (all time) data.
+                const rawData = await getLeaderboard(); 
                 
                 let transformedData = rawData.map((user, index) => ({
                     id: user.id,
@@ -70,8 +70,8 @@ const LeaderboardPage = () => {
         };
 
         fetchLeaderboard();
-        // YENİ: timeframe değiştiğinde useEffect tekrar çalışsın
-    }, [navigate, currentUserId, timeframe]);
+        // CHANGE: Removed timeframe from dependency array since it's disabled
+    }, [navigate, currentUserId]); 
 
     const getRankIcon = (rank) => {
         if (rank === 1) return <Icon name="medalGold" className="rank-icon gold" />;
@@ -107,7 +107,8 @@ const LeaderboardPage = () => {
                     <h1><Icon name="trophy" /> {t('leaderboard_page.title')}</h1>
                     <p>{t('leaderboard_page.subtitle')}</p>
                     
-                    {/* YENİ: Filtre Butonları */}
+                    {/*  DISABLED: Filter buttons hidden */}
+                    {/*
                     <div className="leaderboard-filters">
                         {['all', 'yearly', 'monthly', 'weekly', 'daily'].map((period) => (
                             <button
@@ -119,6 +120,7 @@ const LeaderboardPage = () => {
                             </button>
                         ))}
                     </div>
+                    */}
                 </div>
 
                 {loading && (

--- a/practice-app/frontend-web/src/components/stats/PersonalStats.js
+++ b/practice-app/frontend-web/src/components/stats/PersonalStats.js
@@ -63,35 +63,52 @@ const formatNumber = (num) => {
 
 // --- Custom Bar/Area Tooltip ---
 const CustomTooltip = ({ active, payload, label, type, t }) => {
+  // Helper to translate units
+  const getUnitTrans = (u) => {
+      if(!u) return '';
+      const key = u.toLowerCase().trim();
+      return t(`units.${key}`, { defaultValue: u });
+  };
+
   if (active && payload && payload.length) {
     const total = payload.reduce((sum, entry) => sum + (entry.value || 0), 0);
     const unitText = type === 'score' ? t('units.pts') : t('units.logs');
 
     return (
-      <div className="custom-tooltip">
-        <p className="label"><strong>{label}</strong></p>
+      <div className="custom-tooltip" style={{
+          backgroundColor: '#fff', 
+          padding: '10px', 
+          border: '1px solid #ccc', 
+          borderRadius: '5px',
+          boxShadow: '0 2px 5px rgba(0,0,0,0.2)',
+          zIndex: 1000,
+          pointerEvents: 'none' 
+      }}>
+        <p className="label" style={{marginBottom: '5px', borderBottom:'1px solid #eee', paddingBottom:'3px'}}>
+            <strong>{label}</strong>
+        </p>
         <div className="tooltip-items">
             {payload.map((entry, index) => {
                 const dataPoint = entry.payload; 
-                // Extract key prefix (e.g., subcategory_15)
                 const rawKeyPrefix = entry.dataKey.split('_').slice(0, 2).join('_'); 
                 
                 const rawQty = dataPoint[`${rawKeyPrefix}_rawQty`];
                 const unit = dataPoint[`${rawKeyPrefix}_unit`] || '';
+                const translatedUnit = getUnitTrans(unit);
 
                 return (
-                    <p key={index} style={{ color: entry.color, margin: '4px 0', fontSize: '0.9rem' }}>
+                    <p key={index} style={{ color: entry.color, margin: '2px 0', fontSize: '0.85rem' }}>
                         <span style={{fontWeight: '600'}}>{entry.name}:</span>{' '}
                         {type === 'score' 
                             ? `${formatNumber(entry.value)} ${t('units.pts')}` 
-                            : `${formatNumber(rawQty)} ${unit} (${entry.value} ${t('units.logs')})`
+                            : `${formatNumber(rawQty)} ${translatedUnit} (${entry.value} ${t('units.logs')})`
                         }
                     </p>
                 );
             })}
         </div>
         <div className="tooltip-total" style={{ borderTop: '1px solid #eee', marginTop: '8px', paddingTop: '5px' }}>
-            <p><strong>Total: {formatNumber(total)} {unitText}</strong></p>
+            <p><strong>{t('stats_page.tooltips.total', 'Total')}: {formatNumber(total)} {unitText}</strong></p>
         </div>
       </div>
     );
@@ -107,13 +124,20 @@ const CustomPieTooltip = ({ active, payload, totalValue, t }) => {
       const percent = totalValue > 0 ? (value / totalValue) * 100 : 0;
 
       return (
-        <div className="custom-tooltip">
+        <div className="custom-tooltip" style={{
+            backgroundColor: '#fff', 
+            padding: '10px', 
+            border: '1px solid #ccc', 
+            borderRadius: '5px',
+            boxShadow: '0 2px 5px rgba(0,0,0,0.2)',
+            zIndex: 1000
+        }}>
           <p className="label" style={{color: payload[0].fill, marginBottom: '5px'}}><strong>{data.name}</strong></p>
           <div className="tooltip-items">
-              <p>Impact: <strong>{formatNumber(Math.round(data.score))} {t('units.pts')}</strong></p>
-              <p>Frequency: <strong>{data.count} {t('units.logs')}</strong></p>
+              <p>{t('stats_page.tooltips.impact', 'Impact')}: <strong>{formatNumber(Math.round(data.score))} {t('units.pts')}</strong></p>
+              <p>{t('stats_page.tooltips.frequency', 'Frequency')}: <strong>{data.count} {t('units.logs')}</strong></p>
               <p className="highlight-info" style={{marginTop: '5px', borderTop: '1px dashed #ddd', paddingTop: '3px'}}>
-                  Share: <strong>{percent.toFixed(1)}%</strong>
+                  {t('stats_page.tooltips.share', 'Share')}: <strong>{percent.toFixed(1)}%</strong>
               </p>
           </div>
         </div>
@@ -127,16 +151,12 @@ const PersonalStats = () => {
   const navigate = useNavigate();
   
   const [loading, setLoading] = useState(true);
-  // eslint-disable-next-line no-unused-vars
   const [chartLoading, setChartLoading] = useState(false);
   const [error, setError] = useState('');
   const [profile, setProfile] = useState(null);
   const [scoreData, setScoreData] = useState({ total_score: 0 });
   
   const [timeframe, setTimeframe] = useState('daily');
-  const DEFAULTS = { daily: 10, weekly: 10, monthly: 12, yearly: 10 };
-  const [rangeValue, setRangeValue] = useState(DEFAULTS['daily']); 
-
   const [pieMetric, setPieMetric] = useState('score'); 
 
   const [chartData, setChartData] = useState([]); 
@@ -144,14 +164,14 @@ const PersonalStats = () => {
   const [categoryStats, setCategoryStats] = useState([]); 
   
   const [earnedBadgeIds, setEarnedBadgeIds] = useState([]);
-
   const [leaderboardRank, setLeaderboardRank] = useState('N/A');
-  // eslint-disable-next-line no-unused-vars
   const [eventStats, setEventStats] = useState({ participating: 0, total: 0, rate: 0 });
+  
   const [subCategoriesMap, setSubCategoriesMap] = useState({});
   const [rawLogsState, setRawLogsState] = useState([]);
+  
+  const [rawStatsData, setRawStatsData] = useState([]);
 
-  // rawStreakState might be used for the graph, but we will use logs for badge calculation
   // eslint-disable-next-line no-unused-vars
   const [rawStreakState, setRawStreakState] = useState([]); 
 
@@ -177,8 +197,6 @@ const PersonalStats = () => {
   }, [token]);
 
   useEffect(() => {
-    setRangeValue(DEFAULTS[timeframe]);
-    // Fetch new stats from backend when timeframe changes
     if (token && !loading) {
       fetchStatsForTimeframe(timeframe);
     }
@@ -187,224 +205,209 @@ const PersonalStats = () => {
 
   useEffect(() => {
     if (!loading && rawLogsState.length > 0) {
-        // Re-process Pie Chart and Badges when language changes or logs update
-        processCategoryPie(rawLogsState);
         calculateBadges(rawLogsState, scoreData.total_score);
     }
     // eslint-disable-next-line
-  }, [rawLogsState, i18n.language]);
+  }, [rawLogsState]);
+
+  useEffect(() => {
+    if (!loading && rawStatsData.length > 0) {
+        processStatsData(rawStatsData, timeframe, subCategoriesMap, rawLogsState);
+    }
+    // eslint-disable-next-line
+  }, [i18n.language]);
 
   const getCategoryTrans = (apiName) => {
       if (!apiName) return t('waste_categories.other');
-      const key = apiName.toLowerCase().trim().replace(/\s+/g, "_");
+      const key = apiName.toLowerCase().trim().replace(/[\s-]+/g, "_");
       return t(`waste_categories.${key}`, { defaultValue: apiName });
   };
 
-  // --- Helper: Real Streak Calculation (based on Logs) ---
   const calculateRealStreak = (logs) => {
     if (!logs || logs.length === 0) return 0;
-
-    // 1. Get unique dates with reset hours
     const uniqueDates = [...new Set(logs.map(log => {
         const d = new Date(log.date_logged);
         return new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
     }))];
-
-    // 2. Sort descending
     uniqueDates.sort((a, b) => b - a);
-
     if (uniqueDates.length === 0) return 0;
-
-    // 3. Check streak
     const today = new Date();
     today.setHours(0, 0, 0, 0);
     const todayTime = today.getTime();
-
     const yesterday = new Date(today);
     yesterday.setDate(yesterday.getDate() - 1);
     const yesterdayTime = yesterday.getTime();
-
     const lastLogDate = uniqueDates[0];
-    // If last log is not today or yesterday, streak is broken
-    if (lastLogDate !== todayTime && lastLogDate !== yesterdayTime) {
-        return 0; 
-    }
-
+    if (lastLogDate !== todayTime && lastLogDate !== yesterdayTime) { return 0; }
     let streak = 1;
     let currentCheck = lastLogDate;
-
     for (let i = 1; i < uniqueDates.length; i++) {
         const prevDate = uniqueDates[i];
         const diffTime = Math.abs(currentCheck - prevDate);
         const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24)); 
-
-        if (diffDays === 1) {
-            streak++;
-            currentCheck = prevDate;
-        } else {
-            break; 
-        }
+        if (diffDays === 1) { streak++; currentCheck = prevDate; } else { break; }
     }
     return streak;
   };
 
-  // --- GRAPH DATA PROCESSING (USING BACKEND STATS API) ---
-  // This method avoids heavy frontend processing and aligns dates correctly based on backend data.
-  const processStatsToChartData = (statsData, period, subCatMap = subCategoriesMap) => {
-    const locale = i18n.language;
+  // --- HELPER: Recursively Fetch All Pages ---
+  // This ensures we get ALL data regardless of pagination limits (e.g. 10 items)
+  const fetchAllPages = async (endpoint, headers) => {
+    let allResults = [];
+    let nextUrl = `${apiUrl}${endpoint}`;
+    
+    // Add page_size param safely
+    if (nextUrl.includes('?')) nextUrl += '&page_size=1000';
+    else nextUrl += '?page_size=1000';
+
+    try {
+        while (nextUrl) {
+            const res = await axios.get(nextUrl, { headers });
+            const data = res.data;
+
+            if (Array.isArray(data)) {
+                // If backend does not paginate and returns list
+                allResults = data;
+                nextUrl = null;
+            } else if (data.results) {
+                // If backend paginates
+                allResults = [...allResults, ...data.results];
+                nextUrl = data.next; // Go to next page
+            } else {
+                // Unknown format or single object (shouldn't happen for lists)
+                nextUrl = null;
+            }
+        }
+    } catch (error) {
+        console.warn("Error fetching pages:", error);
+    }
+    return allResults;
+  };
+
+  // --- GRAPH DATA PROCESSING ---
+  const processStatsData = (statsData, period, subCatMap = subCategoriesMap, logs = rawLogsState) => {
+    const locale = i18n.language; 
     const categoriesSet = new Set();
     const chartDataArray = [];
-    const limit = rangeValue || DEFAULTS[period];
-    
-    // Create date range to show empty days as well
-    const now = new Date();
-    const timePoints = [];
-    const loopLimit = limit - 1;
+    const pieAggregates = {};
 
-    if (period === 'daily') {
-        for (let i = loopLimit; i >= 0; i--) {
-            const d = new Date(); d.setDate(now.getDate() - i);
-            timePoints.push(d);
-        }
-    } else if (period === 'weekly') {
-        for (let i = loopLimit; i >= 0; i--) {
-            const d = new Date(); d.setDate(now.getDate() - (i * 7));
-            timePoints.push(d);
-        }
-    } else if (period === 'monthly') {
-        for (let i = loopLimit; i >= 0; i--) {
-            const d = new Date(now.getFullYear(), now.getMonth() - i, 1);
-            timePoints.push(d);
-        }
-    } else if (period === 'yearly') {
-        for (let i = loopLimit; i >= 0; i--) {
-            const d = new Date(now.getFullYear() - i, 0, 1);
-            timePoints.push(d);
-        }
-    }
-
-    // Map backend data by date key
-    const statsMap = {};
     statsData.forEach(stat => {
-        let key = '';
+        const startDate = new Date(stat.start_date);
+        let displayKey = '';
+
         if (period === 'daily') {
-             const date = new Date(stat.start_date);
-             key = date.toLocaleDateString(locale, { month: 'short', day: 'numeric', year: 'numeric' });
+             displayKey = startDate.toLocaleDateString(locale, { month: 'short', day: 'numeric', year: 'numeric' });
         } else if (period === 'weekly') {
-             const startDate = new Date(stat.start_date);
              const day = startDate.getDay();
              const diff = startDate.getDate() - day + (day === 0 ? -6 : 1);
              const monday = new Date(startDate); monday.setDate(diff);
-             key = `${monday.toLocaleDateString(locale, { month: 'short', day: 'numeric' })} ${t('stats_page.charts.week_suffix')}`;
+             displayKey = `${monday.toLocaleDateString(locale, { month: 'short', day: 'numeric' })} ${t('stats_page.charts.week_suffix')}`;
         } else if (period === 'monthly') {
-             const date = new Date(stat.start_date);
-             key = date.toLocaleDateString(locale, { month: 'short', year: 'numeric' });
+             displayKey = startDate.toLocaleDateString(locale, { month: 'short', year: 'numeric' });
         } else if (period === 'yearly') {
-             const date = new Date(stat.start_date);
-             key = date.getFullYear().toString();
+             displayKey = startDate.getFullYear().toString();
         }
-        statsMap[key] = stat;
-    });
 
-    // Populate Chart Data Array
-    timePoints.forEach(d => {
-        let key = '';
-        let displayKey = '';
-        
-        if (period === 'daily') {
-            displayKey = d.toLocaleDateString(locale, { month: 'short', day: 'numeric', year: 'numeric' });
-        } else if (period === 'weekly') {
-            const day = d.getDay();
-            const diff = d.getDate() - day + (day === 0 ? -6 : 1);
-            const monday = new Date(d); monday.setDate(diff);
-            displayKey = `${monday.toLocaleDateString(locale, { month: 'short', day: 'numeric' })} ${t('stats_page.charts.week_suffix')}`;
-        } else if (period === 'monthly') {
-            displayKey = d.toLocaleDateString(locale, { month: 'short', year: 'numeric' });
-        } else if (period === 'yearly') {
-            displayKey = d.getFullYear().toString();
-        }
-        
-        const stat = statsMap[displayKey];
         const entry = { name: displayKey };
+        entry.totalScore = stat.total_score;
+        entry.totalLog = stat.total_log;
 
-        if (stat) {
-             entry.totalScore = stat.total_score;
-             entry.totalLog = stat.total_log;
+        Object.keys(stat).forEach(k => {
+             if (k.match(/^subcategory_\d+_score$/)) {
+                 const subcatId = k.match(/subcategory_(\d+)_score/)[1];
+                 const safeKey = `subcategory_${subcatId}`;
+                 const scoreValue = stat[k];
+                 const logValue = stat[`subcategory_${subcatId}_log`] || 0;
 
-             Object.keys(stat).forEach(k => {
-                // Find keys like subcategory_15_score
-                if (k.match(/^subcategory_\d+_score$/)) {
-                    const subcatId = k.match(/subcategory_(\d+)_score/)[1];
-                    const safeKey = `subcategory_${subcatId}`;
-                    const scoreValue = stat[k];
-                    const logValue = stat[`subcategory_${subcatId}_log`] || 0;
-                    const rawQty = stat[`subcategory_${subcatId}_quantity`] || 0;
+                 const rawQty = logs
+                    .filter(l => {
+                        if (l.sub_category !== parseInt(subcatId)) return false;
+                        const logDate = new Date(l.date_logged).toISOString().split('T')[0];
+                        return logDate >= stat.start_date && logDate <= stat.end_date;
+                    })
+                    .reduce((sum, l) => sum + (parseFloat(l.quantity) || 0), 0);
 
-                    if (scoreValue > 0 || logValue > 0) {
-                        categoriesSet.add(safeKey);
-                        entry[`${safeKey}_score`] = scoreValue;
-                        entry[`${safeKey}_count`] = logValue;
-                        entry[`${safeKey}_rawQty`] = rawQty;
+                 if (scoreValue > 0 || logValue > 0) {
+                     categoriesSet.add(safeKey);
+                     entry[`${safeKey}_score`] = scoreValue;
+                     entry[`${safeKey}_count`] = logValue;
+                     entry[`${safeKey}_rawQty`] = parseFloat(rawQty.toFixed(2)); 
 
-                        const subCatData = subCatMap[subcatId];
-                        const displayName = subCatData ? subCatData.name : `Subcategory ${subcatId}`;
-                        const unit = subCatData ? subCatData.unit : '';
-                        
-                        entry[`${safeKey}_originalName`] = displayName;
-                        entry[`${safeKey}_unit`] = unit;
-                    }
-                }
-             });
-        }
+                     let displayName = `Subcategory ${subcatId}`;
+                     let unit = '';
+
+                     // Map lookup - now guaranteed to be populated for all active categories
+                     const subCatData = subCatMap[subcatId];
+                     if (subCatData) {
+                       displayName = subCatData.name;
+                       unit = subCatData.unit; 
+                     } else {
+                       // Fallback only if really missing (e.g. inactive category)
+                       const fallbackLog = logs.find(l => l.sub_category === parseInt(subcatId));
+                       if (fallbackLog && fallbackLog.sub_category_name) {
+                           displayName = fallbackLog.sub_category_name;
+                       }
+                     }
+                     
+                     entry[`${safeKey}_originalName`] = displayName;
+                     entry[`${safeKey}_unit`] = unit;
+
+                     const transName = getCategoryTrans(displayName);
+                     if (!pieAggregates[transName]) {
+                         pieAggregates[transName] = { name: transName, score: 0, count: 0 };
+                     }
+                     pieAggregates[transName].score += scoreValue;
+                     pieAggregates[transName].count += logValue;
+                 }
+             }
+        });
+
         chartDataArray.push(entry);
     });
 
     setUniqueCategories(Array.from(categoriesSet));
     setChartData(chartDataArray);
+    setCategoryStats(Object.values(pieAggregates));
   };
 
   const fetchInitialData = async () => {
     try {
       const headers = { Authorization: `Bearer ${token}` };
       
-      const [profileRes, scoreRes, logsRes, eventsRes, leaderboardRes, subCatsRes, statsRes] = await Promise.all([
+      // We fetch independent endpoints in parallel, but handle SubCategories & Logs with the fetchAllPages helper
+      // to ensure we get ALL data despite pagination.
+      const [profileRes, scoreRes, leaderboardRes, eventsRes] = await Promise.all([
         axios.get(`${apiUrl}/user/me/`, { headers }),
         axios.get(`${apiUrl}/v1/waste/scores/me/`, { headers }),
-        axios.get(`${apiUrl}/v1/waste/logs/`, { headers }), 
-        axios.get(`${apiUrl}/v1/events/events/`, { headers }),
         axios.get(`${apiUrl}/v1/waste/leaderboard/`, { headers }),
-        axios.get(`${apiUrl}/v1/waste/subcategories/`, { headers }),
-        // Stats data fetched specifically for charts
-        axios.get(`${apiUrl}/v1/waste/user/stats/?period=${timeframe}`, { headers }) 
+        axios.get(`${apiUrl}/v1/events/events/`, { headers })
       ]);
+
+      // Fetch ALL Subcategories (Recursively)
+      const allSubCats = await fetchAllPages('/v1/waste/subcategories/', headers);
+      
+      // Fetch ALL Logs (Recursively) - just in case logs also paginate heavily
+      const allLogs = await fetchAllPages('/v1/waste/logs/', headers);
+
+      // Fetch Stats (Standard fetch, usually returns fixed list)
+      const statsRes = await axios.get(`${apiUrl}/v1/waste/user/stats/?period=${timeframe}`, { headers });
 
       setProfile(profileRes.data);
       setScoreData(scoreRes.data);
       
       const catMap = {};
-      const subCats = subCatsRes.data.results || subCatsRes.data || [];
-      
-      // Pagination handling (To fetch all if there are many subcategories)
-      // Optional: Logic to fetch next pages if necessary can be added here
-      let allSubCats = [...(Array.isArray(subCats) ? subCats : [])];
-      
       allSubCats.forEach(sc => { catMap[sc.id] = sc; });
       setSubCategoriesMap(catMap);
 
-      const allLogs = logsRes.data.results || [];
       const statsData = statsRes.data.data || [];
 
       setRawLogsState(allLogs);
-      
-      // Use Backend Stats data for charts
-      processStatsToChartData(statsData, timeframe, catMap);
-      
-      // Use Raw Logs for Pie Chart and Badges
-      processCategoryPie(allLogs);
+      setRawStatsData(statsData);
+
+      processStatsData(statsData, timeframe, catMap, allLogs);
       calculateBadges(allLogs, scoreRes.data.total_score);
-      
       calculateRank(leaderboardRes.data || [], userId);
-      calculateEventStats(eventsRes.data.results || []);
+      calculateEventStats(eventsRes.data.results || eventsRes.data || []); // Handle both paginated/non-paginated for events too
 
       setLoading(false);
     } catch (err) {
@@ -420,7 +423,9 @@ const PersonalStats = () => {
       const headers = { Authorization: `Bearer ${token}` };
       const statsRes = await axios.get(`${apiUrl}/v1/waste/user/stats/?period=${period}`, { headers });
       const statsData = statsRes.data.data || [];
-      processStatsToChartData(statsData, period, subCategoriesMap);
+      
+      setRawStatsData(statsData);
+      processStatsData(statsData, period, subCategoriesMap, rawLogsState);
       setChartLoading(false);
     } catch (err) {
       console.error(err);
@@ -442,25 +447,6 @@ const PersonalStats = () => {
       }
     }
     return { current, next, currentIndex };
-  };
-
-  const processCategoryPie = (logs) => {
-    const categoryMap = {};
-    logs.forEach(log => {
-      const catName = log.sub_category_name || 'Other';
-      const transName = getCategoryTrans(catName);
-
-      if (!categoryMap[transName]) {
-          categoryMap[transName] = { 
-              name: transName, 
-              score: 0, 
-              count: 0 
-          };
-      }
-      categoryMap[transName].score += parseFloat(log.score) || 0;
-      categoryMap[transName].count += 1;
-    });
-    setCategoryStats(Object.values(categoryMap));
   };
 
   const calculateBadges = (logs, score) => {
@@ -597,17 +583,6 @@ const PersonalStats = () => {
                 <div className="chart-header">
                     <h2>{t('stats_page.charts.points_history')}</h2>
                     <div className="stats-filter-group">
-                        <div className="range-selector">
-                            <span style={{fontSize:'0.85rem', color:'var(--dashboard-text-medium)', marginRight:'5px'}}>{t('stats_page.charts.last')}</span>
-                            <input 
-                                type="number" 
-                                min="1" 
-                                max="365" 
-                                value={rangeValue} 
-                                onChange={(e) => setRangeValue(Number(e.target.value))}
-                                className="range-input"
-                            />
-                        </div>
                         {['daily', 'weekly', 'monthly', 'yearly'].map((p) => (
                             <button 
                                 key={p}
@@ -632,7 +607,11 @@ const PersonalStats = () => {
                                     tick={{ fontSize: 10, dy: 10 }}
                                 />
                                 <YAxis tick={{ fontSize: 11 }} />
-                                <Tooltip content={<CustomTooltip type="score" t={t} />} cursor={{fill: 'transparent'}}/>
+                                <Tooltip 
+                                    content={<CustomTooltip type="score" t={t} />} 
+                                    cursor={{fill: 'transparent'}}
+                                    wrapperStyle={{ zIndex: 1000 }}
+                                />
                                 <Legend wrapperStyle={{paddingTop: '40px'}} />
                                 {uniqueCategories.map((safeKey, index) => {
                                     const originalName = chartData.find(d => d[`${safeKey}_originalName`])?.[`${safeKey}_originalName`] || safeKey;
@@ -672,7 +651,11 @@ const PersonalStats = () => {
                                 tick={{ fontSize: 10, dy: 10 }}
                             />
                             <YAxis allowDecimals={false} tick={{ fontSize: 11 }} />
-                            <Tooltip content={<CustomTooltip type="items" t={t} />} cursor={{fill: 'transparent'}}/>
+                            <Tooltip 
+                                content={<CustomTooltip type="items" t={t} />} 
+                                cursor={{fill: 'transparent'}}
+                                wrapperStyle={{ zIndex: 1000 }}
+                            />
                             <Legend wrapperStyle={{paddingTop: '40px'}} />
                             {uniqueCategories.map((safeKey, index) => {
                                 const originalName = chartData.find(d => d[`${safeKey}_originalName`])?.[`${safeKey}_originalName`] || safeKey;
@@ -720,7 +703,10 @@ const PersonalStats = () => {
                             <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
                           ))}
                         </Pie>
-                        <Tooltip content={<CustomPieTooltip totalValue={pieTotal} t={t} />} />
+                        <Tooltip 
+                            content={<CustomPieTooltip totalValue={pieTotal} t={t} />} 
+                            wrapperStyle={{ zIndex: 1000 }}
+                        />
                         <Legend verticalAlign="bottom" height={36} wrapperStyle={{fontSize: '12px'}} />
                       </PieChart>
                     </ResponsiveContainer>

--- a/practice-app/frontend-web/src/locales/en/translation.json
+++ b/practice-app/frontend-web/src/locales/en/translation.json
@@ -275,11 +275,26 @@
       "content": "\"Reduce your carbon footprint by choosing locally sourced and seasonal foods. It supports local farmers and reduces transportation emissions!\"",
       "discover_more": "Discover more tips"
     },
+    "roles": {
+      "user": "User",
+      "admin": "Admin",
+      "moderator": "Moderator"
+    },
+    "milestones": {
+      "rising_star": "Log waste to reach 500 points and earn Rising Star badge!",
+      "tree_hugger": "Log waste to reach 1000 points and plant your first tree!",
+      "green_achiever": "Log waste to reach 1500 points and earn Green Achiever badge!",
+      "eco_champion": "Log waste to reach 2000 points and become an Eco Champion!",
+      "eco_master": "Log waste to reach 3000 points and become an Eco Master!",
+      "zero_waste_legend": "Log waste to reach 5000 points and become a Zero Waste Legend!",
+      "complete": "You've reached all major milestones! Keep going to maintain your achievements!"
+    },
     "next_step_widget": {
       "title": "Your Next Step",
       "current_score": "Current Score",
       "items_needed": "Items needed",
-      "log_now": "Log Waste Now"
+      "log_now": "Log Waste Now",
+      "progress_text": "{{percent}}% - Need {{needed}} more {{unit}}"
     },
     "forest_widget": {
       "title": "Your Eco Forest",
@@ -575,6 +590,12 @@
       "eco_advocate": "Eco Advocate",
       "green_starter": "Green Starter",
       "eco_explorer": "Eco Explorer"
+    },
+    "tooltips": {
+      "total": "Total",
+      "impact": "Impact",
+      "frequency": "Frequency",
+      "share": "Share"
     }
   },
   "waste_categories": {

--- a/practice-app/frontend-web/src/locales/tr/translation.json
+++ b/practice-app/frontend-web/src/locales/tr/translation.json
@@ -270,6 +270,20 @@
       "view_leaderboard": "Lider Tablosunu Görüntüle",
       "view_leaderboard_sub": "En iyi performans gösterenleri görün"
     },
+    "roles": {
+      "user": "Kullanıcı",
+      "admin": "Yönetici",
+      "moderator": "Moderatör"
+    },
+    "milestones": {
+      "rising_star": "500 puana ulaşıp Yükselen Yıldız rozetini kazanmak için atık gir!",
+      "tree_hugger": "1000 puana ulaşıp ilk ağacını dikmek için atık gir!",
+      "green_achiever": "1500 puana ulaşıp Yeşil Başaran rozetini kazanmak için atık gir!",
+      "eco_champion": "2000 puana ulaşıp Eko Şampiyon olmak için atık gir!",
+      "eco_master": "3000 puana ulaşıp Eko Usta olmak için atık gir!",
+      "zero_waste_legend": "5000 puana ulaşıp Sıfır Atık Efsanesi olmak için atık gir!",
+      "complete": "Tüm ana hedeflere ulaştın! Başarılarını korumak için devam et!"
+    },
     "eco_tip_widget": {
       "title": "Günün Eko İpucu",
       "content": "\"Yerel kaynaklı ve mevsimlik yiyecekleri seçerek karbon ayak izinizi azaltın. Bu, yerel çiftçileri destekler ve ulaşım emisyonlarını azaltır!\"",
@@ -279,7 +293,8 @@
       "title": "Sonraki Adımınız",
       "current_score": "Mevcut Puanınız",
       "items_needed": "Gerekli öğeler",
-      "log_now": "Şimdi Atık Kaydet"
+      "log_now": "Şimdi Atık Kaydet",
+      "progress_text": "%{{percent}} - {{needed}} {{unit}} daha gerekli"
     },
     "forest_widget": {
       "title": "Sizin Eko Ormanınız",
@@ -534,7 +549,7 @@
       "eco_score": "Eko Puan",
       "global_rank": "Küresel Sıralama",
       "event_rate": "Etkinlik Oranı",
-      "trees_planted": "Dikilen Ağaçlar",
+      "trees_planted": "Dİkİlen Ağaçlar",
       "joined_subtext": "katılım"
     },
     "charts": {
@@ -575,6 +590,12 @@
       "eco_advocate": "Eko Savunucu",
       "green_starter": "Yeşil Başlangıç",
       "eco_explorer": "Eko Kaşif"
+    },
+    "tooltips": {
+      "total": "Toplam",
+      "impact": "Etki",
+      "frequency": "Sıklık",
+      "share": "Pay"
     }
   },
   "waste_categories": {


### PR DESCRIPTION
# fix: Improve logic and UI for Personal Stats, Leaderboard, and Dashboard

**Branch:** `fix/stats-dashboard-leaderboard-improvements`

## 📋 Summary
This PR consolidates improvements and fixes across three main areas: the **Leaderboard**, **Personal Stats**, and the **Dashboard**. Major changes include handling backend pagination limits, disabling unsupported filtering options, and implementing full internationalization (i18n) for dynamic content.

## 🔧 Key Changes

### 🏆 Leaderboard
* **Disabled Timeframe Filtering:** The backend endpoint currently only supports "all-time" data. The filtering buttons have been commented out (preserved for future use) and the API call parameters have been removed to prevent errors.
* **UI Update:** Removed the non-functional filter UI to match current backend capabilities.

### 📊 Personal Stats
* **Pagination Fix:** Implemented a recursive fetch mechanism to retrieve all logs/categories. This resolves the issue where data beyond the 10th item (default page limit) was missing from charts.
* **UI/UX Improvements:**
  * Fixed `z-index` issues where chart tooltips overlapped with legends.
  * Removed manual date range selection (dynamic days) to align with strict backend periods (Daily, Weekly, Monthly, Yearly).
* **Translation Support:** Added translation keys for chart units (kg, pcs/adet) and static text (Total, Impact). The charts now dynamically update when the language changes.
* **Data Calculation:** Since the `stats` endpoint does not return quantity, this is now calculated on the frontend from raw logs for the tooltips.

### 🏠 Dashboard
* **Missing Translations:** Refactored logic to replace hardcoded strings with dynamic translation keys.
* **Scope:** Added i18n support for User Roles (e.g., Admin/User), Milestone messages, and Progress Bar text.

## ⚠️ Notes & Dependencies
* **Translation Files:** New keys have been added to `translation.json` for `units`, `stats_page.tooltips`, `roles`, and `milestones`. Please ensure these are synced.
* **Code Preservation:** The filtering logic in `LeaderboardPage.js` was not deleted but commented out to facilitate easy re-enabling once the backend supports period filtering.

## ✅ Checklist
- [x] Leaderboard filtering disabled to match backend.
- [x] Personal Stats pagination and translations fixed.
- [x] Dashboard dynamic content (roles/milestones) is now translatable.
- [x] Verified chart rendering after language switches.